### PR TITLE
Add new packet implementation

### DIFF
--- a/contrib/modular-transport/helper/mt-packet.cc
+++ b/contrib/modular-transport/helper/mt-packet.cc
@@ -1,21 +1,30 @@
 #include "mt-packet.h"
  
 namespace ns3 {
-  int pkt_t::len() { return header.GetSerializedSize() + data.len(); }
+  int pkt_t::len() { return GetSize(); }
 
-  void pkt_t::add_data(stream newData) {
-    data.mem_append((addr_t) &newData, newData.len());
+  void pkt_t::add_data(Buffer newData) {
+    // can't initialize a Packet with a Buffer object, instead need to pass in a uint8_t * and size
+    int bufferSize = newData.GetSize();
+    uint8_t * data = new uint8_t[bufferSize];
+    newData.CopyData(data, bufferSize);
+    Packet toAdd = Packet(data, bufferSize);
+    AddAtEnd(Ptr<Packet>(&toAdd));
+    // delete data array since the Packet constructor copies from it, so it's no longer needed
+    delete[] data;
   }
 
-  stream pkt_t::get_data() { return data; }
+  void pkt_t::get_data(uint8_t * outputBuffer, int bytesToCopy) { 
+    CopyData(outputBuffer, bytesToCopy);
+  }
 
   void pkt_t::add_hdr(MTHeader header) {
-    this->header = header;
+    AddHeader(header);
   }
 
-  MTHeader pkt_t::extract_hdr(MTHeader header) {
-    MTHeader retval = header;
-    header = MTHeader();
+  MTHeader pkt_t::extract_hdr() {
+    MTHeader retval = MTHeader();
+    RemoveHeader(retval);
     return retval;
   }
 }

--- a/contrib/modular-transport/helper/mt-packet.h
+++ b/contrib/modular-transport/helper/mt-packet.h
@@ -16,9 +16,16 @@ namespace ns3 {
     public:
       pkt_t();
       ~pkt_t();
+      
+      // length in bytes
       int len();
+
       void add_data(Buffer newData);
+
+      // copies bytesToCopy bytes (ideally pkt_t::len()) from the packet's 
+      // buffer to outputBuffer, which should be preallocated
       void get_data(uint8_t * outputBuffer, int bytesToCopy);
+
       void add_hdr(MTHeader header);
       MTHeader extract_hdr();
   };

--- a/contrib/modular-transport/helper/mt-packet.h
+++ b/contrib/modular-transport/helper/mt-packet.h
@@ -4,21 +4,23 @@
 #include "mt-header.h"
 #include "mtp-types.h"
 #include "ns3/packet.h"
+#include "ns3/buffer.h"
 
+const int UDP_DATA_BIT_SIZE = 524056; // 65507 bytes
 namespace ns3 {
   // should we even inherit from ns3 Packet?
   class pkt_t : public Packet {
     private:
-      MTHeader header;
-      stream data;
+      // header is MTHeader type 
+      // data is Buffer type - included in ns3's Packet class in a field called m_buffer
     public:
       pkt_t();
       ~pkt_t();
       int len();
-      void add_data(stream newData);
-      stream get_data();
+      void add_data(Buffer newData);
+      void get_data(uint8_t * outputBuffer, int bytesToCopy);
       void add_hdr(MTHeader header);
-      MTHeader extract_hdr(MTHeader header);
+      MTHeader extract_hdr();
   };
 
   pkt_t new_pkt() { return pkt_t(); }


### PR DESCRIPTION
For the add_data function, we can make its parameters either just a ns3::Buffer object or (uint8_t * bytes, int size).
This implementation should make proper use of the ns3::Packet (and associated) classes.